### PR TITLE
Added additional Chrome options as constructor argument

### DIFF
--- a/webwhatsapi/__init__.py
+++ b/webwhatsapi/__init__.py
@@ -151,7 +151,7 @@ class WhatsAPIDriver(object):
         self.driver.close()
 
     def __init__(self, client="firefox", username="API", proxy=None, command_executor=None, loadstyles=False,
-                 profile=None, headless=False, autoconnect=True, logger=None, extra_params=None):
+                 profile=None, headless=False, autoconnect=True, logger=None, extra_params=None, chrome_options=None):
         "Initialises the webdriver"
 
         self.logger = logger or self.logger
@@ -202,6 +202,8 @@ class WhatsAPIDriver(object):
                 self._profile.add_argument("user-data-dir=%s" % self._profile_path)
             if proxy is not None:
                 profile.add_argument('--proxy-server=%s' % proxy)
+            for option in chrome_options:
+                self._profile.add_argument(option)
             self.driver = webdriver.Chrome(chrome_options=self._profile, **extra_params)
 
         elif client == 'remote':
@@ -262,7 +264,7 @@ class WhatsAPIDriver(object):
         if filename is None:
             fd, fn_png = tempfile.mkstemp(prefix=self.username, suffix='.png')
         else:
-            fd = os.open(filename, os.O_RDWR | os.CREAT)
+            fd = os.open(filename, os.O_RDWR | os.O_CREAT)
             fn_png = os.path.abspath(filename)
         self.logger.debug("QRcode image saved at %s" % fn_png)
         qr.screenshot(fn_png)

--- a/webwhatsapi/objects/contact.py
+++ b/webwhatsapi/objects/contact.py
@@ -17,9 +17,12 @@ class Contact(WhatsappObjectWithId):
         :type driver: WhatsAPIDriver
         """
         super(Contact, self).__init__(js_obj, driver)
-        self.short_name = js_obj["shortName"]
-        self.push_name = js_obj["pushname"]
-        self.formatted_name = js_obj["formattedName"]
+        if 'shortName' in js_obj:
+            self.short_name = js_obj["shortName"]
+        if 'pushname' in js_obj:
+            self.push_name = js_obj["pushname"]
+        if 'formattedName' in js_obj:
+            self.formatted_name = js_obj["formattedName"]
 
     @driver_needed
     def get_common_groups(self):

--- a/webwhatsapi/objects/message.py
+++ b/webwhatsapi/objects/message.py
@@ -24,7 +24,7 @@ def factory_message(js_obj, driver):
     if js_obj["isNotification"]:
         return NotificationMessage(js_obj, driver)
 
-    if js_obj["isMMS"]:
+    if 'isMMS' in js_obj and js_obj["isMMS"]:
         return MMSMessage(js_obj, driver)
 
     if js_obj["type"] in ["vcard", "multi_vcard"]:

--- a/webwhatsapi/objects/whatsapp_object.py
+++ b/webwhatsapi/objects/whatsapp_object.py
@@ -71,7 +71,8 @@ class WhatsappObjectWithId(WhatsappObject):
         """
         super(WhatsappObjectWithId, self).__init__(js_obj, driver)
         self.id = js_obj["id"]
-        self.name = js_obj["name"]
+        if 'name' in js_obj:
+            self.name = js_obj["name"]
 
     def __hash__(self):
         return hash(self.id)

--- a/webwhatsapi/objects/whatsapp_object.py
+++ b/webwhatsapi/objects/whatsapp_object.py
@@ -70,7 +70,8 @@ class WhatsappObjectWithId(WhatsappObject):
         :type driver: WhatsAPIDriver
         """
         super(WhatsappObjectWithId, self).__init__(js_obj, driver)
-        self.id = js_obj["id"]
+        if 'id' in js_obj:
+            self.id = js_obj["id"]
         if 'name' in js_obj:
             self.name = js_obj["name"]
 

--- a/webwhatsapi/wapi_js_wrapper.py
+++ b/webwhatsapi/wapi_js_wrapper.py
@@ -45,7 +45,11 @@ class WapiJsWrapper(object):
         with open(os.path.join(script_path, "js", "wapi.js"), "r") as script:
             self.driver.execute_script(script.read())
 
-        return self.driver.execute_script("return window.WAPI").keys()
+        result = self.driver.execute_script("return window.WAPI")
+        if result:
+            return result.keys()
+        else:
+            return []
 
 
 class JsArg(object):


### PR DESCRIPTION
- You can now pass `chrome_options` argument to constructor with a list of additional options (for example `['headless', 'disable-gpu']`
- Fixed `os.CREAT` to `os.O_CREAT` misspelling