### PR TITLE
get_unread now uses unreadCount attribute from Chat object to return unread messages

### DIFF
--- a/webwhatsapi/__init__.py
+++ b/webwhatsapi/__init__.py
@@ -305,17 +305,20 @@ class WhatsAPIDriver(object):
         """
         return self.wapi_functions.getAllChatIds()
 
-    def get_unread(self, include_me=False, include_notifications=False):
+    def get_unread(self, include_me=False, include_notifications=False, use_unread_count=False):
         """
         Fetches unread messages
+
         :param include_me: Include user's messages
         :type include_me: bool or None
         :param include_notifications: Include events happening on chat
         :type include_notifications: bool or None
+        :param use_unread_count: If set uses chat's 'unreadCount' attribute to fetch last n messages from chat
+        :type use_unread_count: bool
         :return: List of unread messages grouped by chats
         :rtype: list[MessageGroup]
         """
-        raw_message_groups = self.wapi_functions.getUnreadMessages(include_me, include_notifications)
+        raw_message_groups = self.wapi_functions.getUnreadMessages(include_me, include_notifications, use_unread_count)
 
         unread_messages = []
         for raw_message_group in raw_message_groups:

--- a/webwhatsapi/js/wapi.js
+++ b/webwhatsapi/js/wapi.js
@@ -627,7 +627,7 @@ function isChatMessage(message) {
 }
 
 
-window.WAPI.getUnreadMessages = function (includeMe, includeNotifications, done) {
+window.WAPI.getUnreadMessages = function (includeMe, includeNotifications, use_unread_count, done) {
     const chats = Store.Chat.models;
     let output = [];
     for (let chat in chats) {
@@ -643,10 +643,10 @@ window.WAPI.getUnreadMessages = function (includeMe, includeNotifications, done)
         for (let i = messages.length - 1; i >= 0; i--) {
             let messageObj = messages[i];
             if (messageObj.__x_isNewMsg || messageObj.__x_MustSent) {
-                let message = WAPI.processMessageObj(messageObj, includeMe,  includeNotifications);
+                let message = WAPI.processMessageObj(messageObj, includeMe, includeNotifications);
                 if(message){
-                    messageObj.__x_isNewMsg = false;    
-                    messageObj.__x_MustSent = false;    
+                    messageObj.__x_isNewMsg = false;
+                    messageObj.__x_MustSent = false;
                     messageGroup.messages.unshift(message);
                 }
             } else {
@@ -656,7 +656,34 @@ window.WAPI.getUnreadMessages = function (includeMe, includeNotifications, done)
 
         if (messageGroup.messages.length > 0) {
             output.push(messageGroup);
+        } else { // no messages with isNewMsg true
+            if (use_unread_count) {
+                let n = messageGroupObj.__x_unreadCount; // will use unreadCount attribute to fetch last n messages from sender
+                for (let i = messages.length - 1; i >= 0; i--) {
+                    let messageObj = messages[i];
+                    if (n > 0) {
+                        if (!messageObj.__x_isSentByMe) {
+                            let message = WAPI.processMessageObj(messageObj, includeMe, includeNotifications);
+                            messageGroup.messages.unshift(message);
+                            n -= 1;
+                        }
+                    } else if (n === -1) { // chat was marked as unread so will fetch last message as unread
+                        if (!messageObj.__x_isSentByMe) {
+                            let message = WAPI.processMessageObj(messageObj, includeMe, includeNotifications);
+                            messageGroup.messages.unshift(message);
+                            break;
+                        }
+                    } else { // unreadCount = 0
+                        break;
+                    }
+                }
+                if (messageGroup.messages.length > 0) {
+                    messageGroupObj.__x_unreadCount = 0; // reset unread counter
+                    output.push(messageGroup);
+                }
+            }
         }
+
     }
     if (done !== undefined) {
         done(output);
@@ -682,7 +709,7 @@ window.WAPI.markDefaultUnreadMessages = function (done) {
             if (messageObj.__x_isSentByMe) {
                 break;
             } else {
-                messageObj.__x_MustSent = true;    
+                messageObj.__x_MustSent = true;
             }
         }
     }


### PR DESCRIPTION
get_unread function now has a parameter to enable/disable use of unreadCount attribute of Chat objects to retrieve unread messages.

This solves the problem where new messages were received before opening the driver and wouldn't be returned as unread.

If chat is manually marked as unread then the last message of the sender will be returned as unread.