### PR TITLE
Removed yield call from get_all_messages_in_chat

### DIFF
--- a/webwhatsapi/__init__.py
+++ b/webwhatsapi/__init__.py
@@ -380,7 +380,9 @@ class WhatsAPIDriver(object):
 
         messages = []
         for message in message_objs:
-            yield(factory_message(message, self))
+            messages.append(factory_message(message, self))
+
+        return messages
 
     def get_all_message_ids_in_chat(self, chat, include_me=False, include_notifications=False):
         """


### PR DESCRIPTION
- The yield method causes Thread return error. Is really necessary to call Yield in this part of code?