### PR TITLE
updates for contact.py/message.py/wapi.js

### DIFF
--- a/webwhatsapi/js/wapi.js
+++ b/webwhatsapi/js/wapi.js
@@ -317,20 +317,25 @@ window.WAPI.sendImageFromDatabasePicBot = function (picId, chatId, caption) {
     return true;
 };
 
-window.WAPI.sendMessageWithThumb = function (thumb, url, title, description, chatId) {
+window.WAPI.sendMessageWithThumb = function (thumb, url, title, description, chatId, done) {
     var chatSend = WAPI.getChat(chatId);
     if (chatSend === undefined) {
         return false;
     }
     var msgWithImg = chatSend.createMessageFromText(".");
-    msgWithImg.hasLink = title;
-    msgWithImg.body = description + '\n                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ' + url;
-    msgWithImg.isLink = title;
-    msgWithImg.description = description;
-    msgWithImg.subtype = 'url';
-    msgWithImg.title = title;
-    msgWithImg.thumbnail = thumb;
-    return chatSend.addAndSendMsg(msgWithImg);
+    msgWithImg.__x_hasLink = title;
+    msgWithImg.__x_body = description + '\n ' + url;
+    msgWithImg.__x_isLink = title;
+    msgWithImg.__x_description = description;
+    msgWithImg.__x_subtype = 'url';
+    msgWithImg.__x_title = title;
+    msgWithImg.__x_thumbnail = thumb;
+
+    chatSend.addAndSendMsg(msgWithImg);
+
+    if(done!==undefined){
+        done(true);
+    }
 
     return true;
 };

--- a/webwhatsapi/objects/contact.py
+++ b/webwhatsapi/objects/contact.py
@@ -23,6 +23,8 @@ class Contact(WhatsappObjectWithId):
             self.push_name = js_obj["pushname"]
         if 'formattedName' in js_obj:
             self.formatted_name = js_obj["formattedName"]
+        if 'profilePicThumbObj' in js_obj:
+            self.profile_pic = js_obj["profilePicThumbObj"].get('eurl', None)
 
     @driver_needed
     def get_common_groups(self):
@@ -40,7 +42,7 @@ class Contact(WhatsappObjectWithId):
         :rtype: String
 
         """
-        name = (self.name or self.push_name or self.formatted_name)
+        name = (self.short_name or self.push_name or self.formatted_name)
         if (isinstance(name, string_types)):
             safe_name = safe_str(name)
         else:

--- a/webwhatsapi/objects/message.py
+++ b/webwhatsapi/objects/message.py
@@ -95,10 +95,10 @@ class MediaMessage(Message):
         extension = mimetypes.guess_extension(self.mime)
         self.filename = ''.join([str(id(self)), extension or ''])
 
-    def save_media(self, path):
+    def save_media(self, path, force_download=False):
         # gets full media
         filename = os.path.join(path, self.filename)
-        ioobj = self.driver.download_media(self)
+        ioobj = self.driver.download_media(self, force_download)
         with open(filename, "wb") as f:
             f.write(ioobj.getvalue())
         return filename


### PR DESCRIPTION
contact.py allow to get the profile_pic attribute and get the short_name
message.py add the force_download parameter to the function save_media in order to save full image. without this parameter only save a miniature image always
wapi.py fix the problem when it is sent a previw link with the function sendMessageWithThumb