### PR TITLE
fix bug in get_all_chats

### DIFF
--- a/webwhatsapi/__init__.py
+++ b/webwhatsapi/__init__.py
@@ -303,7 +303,11 @@ class WhatsAPIDriver(object):
         :return: List of chats
         :rtype: list[Chat]
         """
-        return [factory_chat(chat, self) for chat in self.wapi_functions.getAllChats()]
+        chats = self.wapi_functions.getAllChats()
+        if chats:
+            return [factory_chat(chat, self) for chat in chats]
+        else:
+            return []
 
     def get_all_chat_ids(self):
         """


### PR DESCRIPTION
I noticed a bug in `get_all_chats()` if there are not chats in the conversation.

I get the `TypeError: 'NoneType' object is not iterable` message.

This small change fixed it