### PR TITLE
Fix to check_number_status for NoneType bug

### DIFF
--- a/webwhatsapi/objects/whatsapp_object.py
+++ b/webwhatsapi/objects/whatsapp_object.py
@@ -71,7 +71,10 @@ class WhatsappObjectWithId(WhatsappObject):
         """
         super(WhatsappObjectWithId, self).__init__(js_obj, driver)
         if 'id' in js_obj:
-            self.id = js_obj["id"]
+            try:
+                self.id = js_obj["id"]["_serialized"]
+            except:
+                self.id = js_obj["id"]
         if 'name' in js_obj:
             self.name = js_obj["name"]
 


### PR DESCRIPTION
As mentioned on #397 and #389, this command was returning the following error when the checked number doesn't exist:
`TypeError: 'NoneType' object is not subscriptable`

This is due to a recently whatsapp modification that outputs jid as undefined, this said what I did was a check if it's undefined on `wapi.js` and if it is, throws the exception before the first command:
```
window.WAPI.checkNumberStatus = function(id, done) {
    window.Store.WapQuery.queryExist(id).then((result) => {
        if(done !== undefined) {
			if(result.jid === undefined) throw 404;
			done(window.WAPI._serializeNumberStatusObj(result));
        }
    }).catch((e) => {
        if(done !== undefined) {
            done(window.WAPI._serializeNumberStatusObj({
                status: e,
                jid: id
            }));
        }
    });
    return true;
};
```

Also, I'm running Python 2.7 on Windows Server 2012 and on whatsapp_object.py I had a code that was checking if js_obj['id] is an str but this way it would never return true, so I'm first trying to get `["_serialized"]` and if it doesn't work, it's probably only the number:
```
if 'id' in js_obj:
            try:
                self.id = js_obj["id"]["_serialized"]
            except:
                self.id = js_obj["id"]
```

Those are the changes, I hope it works for you.