### PR TITLE
Fixed sorting of unread messages (now by timestamp)

### DIFF
--- a/webwhatsapi/__init__.py
+++ b/webwhatsapi/__init__.py
@@ -341,7 +341,7 @@ class WhatsAPIDriver(object):
         for raw_message_group in raw_message_groups:
             chat = factory_chat(raw_message_group, self)
             messages = [factory_message(message, self) for message in raw_message_group['messages']]
-            messages.sort(key=lambda message: message.cid)
+            messages.sort(key=lambda message: message.timestamp)
             unread_messages.append(MessageGroup(chat, messages))
 
         return unread_messages


### PR DESCRIPTION
Fixed sorting when reading new messages. CID is now null, so it is ordering by timestamp attribute.

Related to issue: https://github.com/mukulhase/WebWhatsapp-Wrapper/issues/403
