### PR TITLE
Fix to getProfilePics

### DIFF
--- a/webwhatsapi/__init__.py
+++ b/webwhatsapi/__init__.py
@@ -623,20 +623,32 @@ class WhatsAPIDriver(object):
     def get_profile_pic_from_id(self, id):
         """
         Get full profile pic from an id
+        The ID must be on your contact book to
+        successfully get their profile picture.
 
         :param id: ID
         :type id: str
         """
-        return b64decode(self.wapi_functions.getProfilePicFromId(id))
+        profile_pic = self.wapi_functions.getProfilePicFromId(id)
+        if profile_pic:
+            return b64decode(profile_pic)
+        else:
+            return False
 
     def get_profile_pic_small_from_id(self, id):
         """
         Get small profile pic from an id
+        The ID must be on your contact book to
+        successfully get their profile picture.
 
         :param id: ID
         :type id: str
         """
-        return b64decode(self.wapi_functions.getProfilePicSmallFromId(id))
+        profile_pic_small = self.wapi_functions.getProfilePicSmallFromId(id)
+        if profile_pic:
+            return b64decode(profile_pic_small)
+        else:
+            return False
 
     def download_file(self, url):
         return b64decode(self.wapi_functions.downloadFile(url))

--- a/webwhatsapi/js/wapi.js
+++ b/webwhatsapi/js/wapi.js
@@ -918,7 +918,9 @@ window.WAPI.getProfilePicSmallFromId = function(id, done) {
         } else {
             done(false);
         }
-    })
+    }, function(e) {
+		done(false);
+	})
 };
 
 window.WAPI.getProfilePicFromId = function(id, done) {
@@ -928,7 +930,9 @@ window.WAPI.getProfilePicFromId = function(id, done) {
         } else {
             done(false);
         }
-    })
+    }, function(e) {
+		done(false);
+	})
 };
 
 window.WAPI.downloadFileWithCredentials = function (url, done) {

--- a/webwhatsapi/js/wapi.js
+++ b/webwhatsapi/js/wapi.js
@@ -1138,8 +1138,9 @@ window.WAPI.getBufferedNewMessages = function(done) {
 /** End new messages observable functions **/
 
 window.WAPI.sendImage = function (imgBase64, chatid, filename, caption, done) {
-    var chat = WAPI.getChat(chatid);
-    if (chat !== undefined) {
+	var idUser = new window.Store.UserConstructor(chatid);
+	// create new chat
+	return Store.Chat.find(idUser).then((chat) => {
         var mediaBlob = window.WAPI.base64ImageToFile(imgBase64, filename);
         var mc = new Store.MediaCollection();
         mc.processFiles([mediaBlob], chat, 1).then(() => {
@@ -1147,11 +1148,7 @@ window.WAPI.sendImage = function (imgBase64, chatid, filename, caption, done) {
             media.sendToChat(chat, {caption: caption});
             if (done !== undefined) done(true);
         });
-    } else {
-        if (done !== undefined) done(false);
-        return false;
-    }
-    return true;
+    });
 };
 
 window.WAPI.base64ImageToFile = function (b64Data, filename) {


### PR DESCRIPTION
Trying to get a profile picture would never return `done` when the contact is not on your contacts list.
This happens because the promise `window.Store.ProfilePicThumb.find(id)` rejects it if not found.

That's why I'm using the second _optional_ callback of .then(): `Promise.then(onFulfilled[, onRejected]);`
This is an annoying bug because when it's rejected it will hold every following request as `done` couldn't be reached.

I've been testing this edit for some days now and it works without a problem, just keep in mind to have the contact on your contacts list before trying to get their picture, otherwise it will always return false