### PR TITLE
fixed how to identify geo messages correctly

### DIFF
--- a/webwhatsapi/objects/message.py
+++ b/webwhatsapi/objects/message.py
@@ -23,7 +23,7 @@ def factory_message(js_obj, driver):
     if js_obj is None:
         return
 
-    if js_obj["lat"] and js_obj["lng"]:
+    if "lat" in js_obj and "lng" in js_obj and js_obj["lat"] and js_obj["lng"]:
         return GeoMessage(js_obj, driver)
 
     if js_obj["isMedia"]:

--- a/webwhatsapi/objects/message.py
+++ b/webwhatsapi/objects/message.py
@@ -23,7 +23,7 @@ def factory_message(js_obj, driver):
     if js_obj is None:
         return
 
-    if "lat" in js_obj and "lng" in js_obj:
+    if js_obj["lat"] and js_obj["lng"]:
         return GeoMessage(js_obj, driver)
 
     if js_obj["isMedia"]:


### PR DESCRIPTION
MediaMessage were being identified as GeoMessage, i changed this validation to only enter when lat and lng has value.