### PR TITLE
sendVCard displayName as subtype and undefined Conn fix

### DIFF
--- a/webwhatsapi/js/wapi.js
+++ b/webwhatsapi/js/wapi.js
@@ -1218,7 +1218,6 @@ window.WAPI.sendVCard = function(chatId, vcard) {
 
     var extend = {
         ack: 0,
-        from: Store.Conn.me,
         id: newId,
         local: !0,
         self: "out",
@@ -1237,6 +1236,7 @@ window.WAPI.sendVCard = function(chatId, vcard) {
     } else {
         Object.assign(extend, {
             type: "vcard",
+            subtype: vcard.displayName,
             body: vcard.vcard
         });
 


### PR DESCRIPTION
When the message is vcard type, the displayName can be set on the subtype, hinting the name of the contact to add without having to open the vcard to see the contact name.
Also, removed the dependency on Store.Conn.me since its not needed, and it's not always unpacked properly or on time (still tracing this)