### PR TITLE
ForwardMessage, ReplyMessageWithQuote

### DIFF
--- a/webwhatsapi/js/wapi.js
+++ b/webwhatsapi/js/wapi.js
@@ -647,7 +647,8 @@ window.WAPI.ReplyMessage = function (idMessage, message, done) {
         if (done !== undefined) done(false);
         return false;
     }
-    messageObject = messageObject.value();
+    if (messageObject && 'function' == typeof messageObject.valueOf)
+        messageObject = messageObject.valueOf();
 
     const chat = window.Store.Chat.get(messageObject.chat.id)
     if (chat !== undefined){
@@ -667,7 +668,7 @@ window.WAPI.ReplyMessage = function (idMessage, message, done) {
                             continue;
                         }
                         done(WAPI._serializeMessageObj(msg));
-                        return True;
+                        return true;
                     }
                     trials += 1;
                     console.log(trials);
@@ -882,7 +883,7 @@ window.WAPI.sendMessage = function (id, message, done) {
                             continue;
                         }
                         done(WAPI._serializeMessageObj(msg));
-                        return True;
+                        return true;
                     }
                     trials += 1;
                     console.log(trials);

--- a/webwhatsapi/js/wapi.js
+++ b/webwhatsapi/js/wapi.js
@@ -690,6 +690,77 @@ window.WAPI.ReplyMessage = function (idMessage, message, done) {
     }
 };
 
+/*
+ * Reply with Quote given idMessage with text message
+ * @param
+ */
+window.WAPI.ReplyMessageWithQuote = function(idMessage, message, done) {
+    var messageObject = Store.Msg.get(idMessage);
+
+    if (messageObject === undefined) {
+        if (done !== undefined) done(false);
+        return false;
+    }
+    messageObject = messageObject.valueOf();
+
+    const chat = Store.Chat.get(messageObject.chat.id);
+    if (chat !== undefined) {
+        if (done !== undefined) {
+            let params = {
+                quotedMsg: messageObject
+            };
+            chat.sendMessage(message, params).then(function() {
+                function sleep(ms) {
+                    return new Promise(resolve => setTimeout(resolve, ms));
+                }
+
+                var trials = 0;
+
+                function check() {
+                    let msg = chat.getLastReceivedMsg(),
+                        isSameText = function(a, b) {
+
+                            return escape((a + '').trim()) == escape((b + '').trim())
+                        };
+                    if (!(!msg.senderObj.isMe || !isSameText(msg.body, message))) {
+
+                        done(WAPI._serializeMessageObj(msg));
+                        return true;
+                    }
+
+                    // Failover, loop through from msgs
+                    for (let i = chat.msgs.models.length - 1; i >= 0; i--) {
+                        msg = chat.msgs.models[i];
+
+                        if (!(!msg.senderObj.isMe || !isSameText(msg.body, message))) {
+
+                            done(WAPI._serializeMessageObj(msg));
+                            return true;
+                        }
+                    }
+
+
+                    trials += 1;
+                    console.log(trials);
+                    if (trials > 30) {
+                        done(true);
+                        return;
+                    }
+                    sleep(500).then(check);
+                }
+                check();
+            });
+            return true;
+        } else {
+            chat.sendMessage(message, null, messageObject);
+            return true;
+        }
+    } else {
+        if (done !== undefined) done(false);
+        return false;
+    }
+};
+
 window.WAPI.sendMessageToID = function (id, message, done) {
     try {
         var idUser = new window.Store.UserConstructor(id);

--- a/webwhatsapi/js/wapi.js
+++ b/webwhatsapi/js/wapi.js
@@ -701,14 +701,15 @@ window.WAPI.ReplyMessageWithQuote = function(idMessage, message, done) {
         if (done !== undefined) done(false);
         return false;
     }
-    messageObject = messageObject.valueOf();
+    if (messageObject && 'function' == typeof messageObject.valueOf)
+        messageObject = messageObject.valueOf();
 
     const chat = Store.Chat.get(messageObject.chat.id);
     if (chat !== undefined) {
+        let params = {
+            quotedMsg: messageObject
+        };
         if (done !== undefined) {
-            let params = {
-                quotedMsg: messageObject
-            };
             chat.sendMessage(message, params).then(function() {
                 function sleep(ms) {
                     return new Promise(resolve => setTimeout(resolve, ms));
@@ -752,7 +753,7 @@ window.WAPI.ReplyMessageWithQuote = function(idMessage, message, done) {
             });
             return true;
         } else {
-            chat.sendMessage(message, null, messageObject);
+            chat.sendMessage(message, params);
             return true;
         }
     } else {
@@ -769,15 +770,15 @@ window.WAPI.ReplyMessageWithQuote = function(idMessage, message, done) {
  */
 window.WAPI.ForwardMessage = function(idDestination, idMessage, done) {
     var messageObject = Store.Msg.get(idMessage),
-        destChat = Store.Chat.get(idDestination);
+        chatDest = Store.Chat.get(idDestination);
 
-    if (messageObject === undefined || destChat === undefined) {
+    if (messageObject === undefined || chatDest === undefined) {
         if (done !== undefined) done(false);
         return false;
     }
 
     if (done !== undefined) {
-        destChat.forwardMessages([messageObject]).then(function() {
+        chatDest.forwardMessages([messageObject]).then(function() {
             function sleep(ms) {
                 return new Promise(resolve => setTimeout(resolve, ms));
             }
@@ -785,7 +786,7 @@ window.WAPI.ForwardMessage = function(idDestination, idMessage, done) {
             var trials = 0;
 
             function check() {
-                let msg = destChat.getLastReceivedMsg(),
+                let msg = chatDest.getLastReceivedMsg(),
                     isSameText = function(a, b) {
 
                         return escape((a + '').trim()) == escape((b + '').trim())
@@ -819,7 +820,7 @@ window.WAPI.ForwardMessage = function(idDestination, idMessage, done) {
         });
         return true;
     } else {
-        destChat.sendMessage(message, null, messageObject);
+        chatDest.forwardMessages([messageObject]);
         return true;
     }
 };


### PR DESCRIPTION
I am not sure if these methods were necessary.
But i think it might help for particular task, hehe.

Notes for ForwardMessage(s), there's capability to do forward multiple message, so params `idMessage` can be enhanced become `idMessages`, values of msg.id could be separated with comma or something,. So finding `messageObject` should be inside loop retrieving value from multiple ids of message.

Or maybe, just separate it to another method, say `ForwardMessages` coz it looks quite different in handling params.

Need to recheck..