### PR TITLE
Fixed contact throwing 'not defined' errors

### DIFF
--- a/webwhatsapi/objects/contact.py
+++ b/webwhatsapi/objects/contact.py
@@ -16,6 +16,14 @@ class Contact(WhatsappObjectWithId):
         :param driver:
         :type driver: WhatsAPIDriver
         """
+		
+		self.short_name = None
+        self.push_name = None
+        self.formatted_name = None
+        self.profile_pic = None
+        self.verified_name = None
+        self.is_business = False
+		
         super(Contact, self).__init__(js_obj, driver)
         if 'shortName' in js_obj:
             self.short_name = js_obj["shortName"]

--- a/webwhatsapi/objects/contact.py
+++ b/webwhatsapi/objects/contact.py
@@ -17,7 +17,7 @@ class Contact(WhatsappObjectWithId):
         :type driver: WhatsAPIDriver
         """
 		
-		self.short_name = None
+	self.short_name = None
         self.push_name = None
         self.formatted_name = None
         self.profile_pic = None


### PR DESCRIPTION
When specific keys were not in 'js_obj', the local variable would not be set, throwing 'not defined' errors while retrieving contacts