### PR TITLE
FIX: finish running thread after driver.quit()

### DIFF
--- a/webwhatsapi/__init__.py
+++ b/webwhatsapi/__init__.py
@@ -744,6 +744,7 @@ class WhatsAPIDriver(object):
         self.wapi_functions.new_messages_observable.unsubscribe(observer)
 
     def quit(self):
+        self.wapi_functions.quit()
         self.driver.quit()
 
     def create_chat_by_number(self, number):

--- a/webwhatsapi/wapi_js_wrapper.py
+++ b/webwhatsapi/wapi_js_wrapper.py
@@ -73,6 +73,9 @@ class WapiJsWrapper(object):
         else:
             return []
 
+    def quit(self):
+        self.new_messages_observable.stop()
+
 
 class JsArg(object):
     """
@@ -146,9 +149,11 @@ class NewMessagesObservable(Thread):
         self.wapi_driver = wapi_driver
         self.webdriver = webdriver
         self.observers = []
+        self.running = False
 
     def run(self):
-        while True:
+        self.running = True
+        while self.running:
             try:
                 new_js_messages = self.wapi_js_wrapper.getBufferedNewMessages()
                 if isinstance(new_js_messages, (collections.Sequence, np.ndarray)) and len(new_js_messages) > 0:
@@ -161,6 +166,9 @@ class NewMessagesObservable(Thread):
                 pass
 
             time.sleep(2)
+
+    def stop(self):
+        self.running = False
 
     def subscribe(self, observer):
         inform_method = getattr(observer, "on_message_received", None)


### PR DESCRIPTION
After WhatsAPIDriver.quit(), there's an infinite running thread that keeps checking for new messages every 2 seconds, but it raises an exception because it can't connect to browser anymore.

This PR will exit this thread when driver.quit() is called.