### PR TITLE
Update on wapi.js, GetChat Throwing error

### DIFF
--- a/webwhatsapi/js/wapi.js
+++ b/webwhatsapi/js/wapi.js
@@ -284,7 +284,8 @@ window.WAPI.getAllGroups = function (done) {
 window.WAPI.getChat = function (id, done) {
     id = typeof id == "string" ? id : id._serialized;
     const found = window.Store.Chat.get(id);
-    found.sendMessage = (found.sendMessage) ? found.sendMessage : function () { return window.Store.sendMessage.apply(this, arguments); };
+    if (found)
+        found.sendMessage = (found.sendMessage) ? found.sendMessage : function () { return window.Store.sendMessage.apply(this, arguments); };
     if (done !== undefined) done(found);
     return found;
 }


### PR DESCRIPTION
the function window.WAPI.getChat was throwing error when no chat was found, but it was supposed to return undefined
I just added an "if (found)"
before adding the function sendMessage to object found
If object "found" is undefined is impossible to set a function and this throw an error