### PR TITLE
Bug JavascriptException: Message: Cyclic object value in the latest version of firefox and chrome

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,23 @@
+import sys
+sys.path.append('/home/lucas/Documentos/WhatsappTeste/WebWhatsapp-Wrapper')
+
+import time, logging
+from webwhatsapi import WhatsAPIDriver
+from webwhatsapi.objects.message import Message
+
+logging.getLogger().setLevel(logging.INFO)
+
+driver = WhatsAPIDriver(client="chrome", executable_path="/home/lucas/chromedriver", loadstyles=True)
+print("Waiting for QR")
+driver.wait_for_login()
+
+print("Bot started")
+
+while True:
+    time.sleep(3)
+    print('Checking for more messages')
+    for contact in driver.get_unread():
+        for message in contact.messages:
+            if isinstance(message, Message):  # Currently works for text messages only.
+            	print(message.contact)
+                #contact.chat.send_message(message.content)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ cryptography
 typing
 numpy
 python-magic
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ typing
 numpy
 python-magic
 requests
+pyvirtualdisplay

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ cryptography
 typing
 numpy
 python-magic
-requests

--- a/webwhatsapi/__init__.py
+++ b/webwhatsapi/__init__.py
@@ -776,7 +776,7 @@ class WhatsAPIDriver(object):
         """
         profile_pic = self.wapi_functions.getProfilePicFromId(id)
         if profile_pic:
-            return profile_pic
+            return str(profile_pic)
         else:
             return False
 

--- a/webwhatsapi/__init__.py
+++ b/webwhatsapi/__init__.py
@@ -218,8 +218,13 @@ class WhatsAPIDriver(object):
             if chrome_options is not None:
                 for option in chrome_options:
                     self._profile.add_argument(option)
-            self.logger.info("Starting webdriver")
-            self.driver = webdriver.Chrome(chrome_options=self._profile, **extra_params)
+            
+            if executable_path is not None:
+                self.logger.info("Starting webdriver")
+                self.driver = webdriver.Chrome(executable_path=executable_path, chrome_options=self._profile, **extra_params)
+            else:
+                self.logger.info("Starting webdriver")
+                self.driver = webdriver.Chrome(chrome_options=self._profile, **extra_params)
 
         elif client == 'remote':
             if self._profile_path is not None:

--- a/webwhatsapi/__init__.py
+++ b/webwhatsapi/__init__.py
@@ -69,7 +69,7 @@ class WhatsAPIDriver(object):
 
     _SELECTORS = {
         'firstrun': "#wrapper",
-        'qrCode': "img[alt=\"Scan me!\"]",
+        'qrCode': "canvas[aria-label=\"Scan me!\"]",
         'qrCodePlain': "div[data-ref]",
         'mainPage': ".app.two",
         'chatList': ".infinite-list-viewport",
@@ -284,7 +284,13 @@ class WhatsAPIDriver(object):
         )
 
     def get_qr_plain(self):
-        return self.driver.find_element_by_css_selector(self._SELECTORS['qrCodePlain']).get_attribute("data-ref")
+        if "Click to reload QR code" in self.driver.page_source:
+            self.reload_qr()
+        qr = self.driver.find_element_by_css_selector(self._SELECTORS['qrCode'])
+
+        qr_base64 = self.driver.execute_script("return arguments[0].toDataURL('image/png').substring(22);", qr)
+
+        return "data:image/png;base64," + qr_base64
 
     def get_qr(self, filename=None):
         """Get pairing QR code from client"""
@@ -306,7 +312,9 @@ class WhatsAPIDriver(object):
             self.reload_qr()
         qr = self.driver.find_element_by_css_selector(self._SELECTORS['qrCode'])
 
-        return qr.screenshot_as_base64
+        qr_base64 = self.driver.execute_script("return arguments[0].toDataURL('image/png').substring(22);", qr)
+
+        return qr_base64
 
     def screenshot(self, filename):
         self.driver.get_screenshot_as_file(filename)

--- a/webwhatsapi/__init__.py
+++ b/webwhatsapi/__init__.py
@@ -9,8 +9,6 @@ import logging
 import os
 import shutil
 import tempfile
-import requests
-import mimetypes
 from base64 import b64decode, b64encode
 from io import BytesIO
 from json import dumps, loads
@@ -626,57 +624,6 @@ class WhatsAPIDriver(object):
         imgBase64 = self.convert_to_base64(path)
         filename = os.path.split(path)[-1]
         return self.wapi_functions.sendImage(imgBase64, chatid, filename, caption)
-
-        def send_media_base64(self, base64_string, content_type, chatid, caption, file_name=None):
-        """
-            send file in base 64 using the sendImage function of wapi.js
-        :param base64: base64 string
-        :param content_type: file mime, sample (image/png) https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
-        :param chatid: chatId to be sent
-        :param caption:
-        :param file_name: name of file
-        :return:
-        """
-        extension = mimetypes.guess_extension(content_type)
-
-        if file_name is None:
-            file = 'file' + extension
-        else:
-            file = file_name + extension
-        
-        imgBase64 = 'data:' + content_type + ';base64,' + base64_string
-        
-        return self.wapi_functions.sendImage(imgBase64, chatid, file, caption)
-
-    def send_media_url(self, url, chatid, caption, file_name=None):
-        """
-            download file and send using wapi.js sendImage function
-        :param url: url file
-        :param chatid: chatId to be sent
-        :param caption:
-        :param file_name: name of file
-        :return:
-        """
-        
-        res = requests.get(url)
-
-        if res.status_code == 200:
-            content_type = res.headers['Content-Type']
-            base64_string = b64encode(res.content).decode('utf-8')
-
-            imgBase64 = "data:" + content_type + ";" + "base64," + base64_string
-
-            extension = mimetypes.guess_extension(content_type)
-
-            if file_name is None:
-                file = 'file' + extension
-            else:
-                file = file_name + extension
-
-            return self.wapi_functions.sendImage(imgBase64, chatid, file, caption)
-
-        else:
-            raise Exception('Impossible to access url. Erro : ' + str(res.status_code))
 
     def send_message_with_thumbnail(self, path, chatid, url, title, description, text):
         """

--- a/webwhatsapi/__init__.py
+++ b/webwhatsapi/__init__.py
@@ -220,7 +220,10 @@ class WhatsAPIDriver(object):
             if proxy is not None:
                 self._profile.add_argument('--proxy-server=%s' % proxy)
             if headless:
-                self._profile.add_argument('headless')
+                self._profile.add_argument('--headless')
+                self._profile.add_argument("--window-size=1920x1080")
+                self._profile.add_argument('user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36')
+
             if chrome_options is not None:
                 for option in chrome_options:
                     self._profile.add_argument(option)

--- a/webwhatsapi/js/wapi.js
+++ b/webwhatsapi/js/wapi.js
@@ -67,7 +67,19 @@ if (!window.Store) {
             }
         }
 
-        webpackJsonp([], { 'parasite': (x, y, z) => getStore(z) }, ['parasite']);
+        if (typeof webpackJsonp === 'function') {
+            webpackJsonp([], {'parasite': (x, y, z) => getStore(z)}, ['parasite']);
+        } else {
+            webpackJsonp.push([
+                ['parasite'],
+                {
+                    parasite: function (o, e, t) {
+                        getStore(t);
+                    }
+                },
+                [['parasite']]
+            ]);
+        }
     })();
 }
 

--- a/webwhatsapi/js/wapi.js
+++ b/webwhatsapi/js/wapi.js
@@ -12,7 +12,7 @@ if (!window.Store) {
             let foundCount = 0;
             let neededObjects = [
                 { id: "Store", conditions: (module) => (module.Chat && module.Msg) ? module : null },
-                { id: "MediaCollection", conditions: (module) => (module.default && module.default.prototype && module.default.prototype.processFiles !== undefined) ? module.default : null },
+                { id: "MediaCollection", conditions: (module) => (module.default && module.default.prototype && module.default.prototype.processAttachments) ? module.default : null },
                 { id: "MediaProcess", conditions: (module) => (module.BLOB) ? module : null },
                 { id: "Wap", conditions: (module) => (module.createGroup) ? module : null },
                 { id: "ServiceWorker", conditions: (module) => (module.default && module.default.killServiceWorker) ? module : null },
@@ -710,7 +710,7 @@ window.WAPI.ReplyMessage = function (idMessage, message, done) {
                     }
                     trials += 1;
                     console.log(trials);
-                    if (trials > 30) {
+                    if (trials > 5) { //30
                         done(true);
                         return;
                     }
@@ -798,7 +798,7 @@ window.WAPI.sendMessage = function (id, message, done) {
                     }
                     trials += 1;
                     console.log(trials);
-                    if (trials > 30) {
+                    if (trials > 5) { //30
                         done(true);
                         return;
                     }
@@ -1230,8 +1230,8 @@ var idUser = new window.Store.UserConstructor(chatid, { intentionallyUsePrivateC
 // create new chat
 return Store.Chat.find(idUser).then((chat) => {
     var mediaBlob = window.WAPI.base64ImageToFile(imgBase64, filename);
-    var mc = new Store.MediaCollection();
-    mc.processFiles([mediaBlob], chat, 1).then(() => {
+    var mc = new Store.MediaCollection(chat);
+    mc.processAttachments([{file: mediaBlob}, 1], chat, 1).then(() => {
         var media = mc.models[0];
         media.sendToChat(chat, { caption: caption });
         if (done !== undefined) done(true);

--- a/webwhatsapi/objects/chat.py
+++ b/webwhatsapi/objects/chat.py
@@ -27,6 +27,14 @@ class Chat(WhatsappObjectWithId):
         return self.driver.send_media(image_path, self.id, caption)
 
     @driver_needed
+    def send_media_url(self, url, caption=None, file_name=None):
+        return self.driver.send_media_url(url, self.id, caption, file_name)
+
+    @driver_needed
+    def send_media_base64(self, base64_string, content_type, caption=None, file_name=None):
+        return self.driver.send_media_base64(base64_string, content_type, self.id, caption, file_name)
+
+    @driver_needed
     def send_message_with_thumb(self, image_path, url, title, description, text):
         return self.driver.send_message_with_thumbnail(image_path, self.id, url, title, description, text)
 

--- a/webwhatsapi/objects/message.py
+++ b/webwhatsapi/objects/message.py
@@ -1,5 +1,6 @@
 import mimetypes
 import os
+from base64 import b64encode
 from datetime import datetime
 from typing import Union
 
@@ -101,6 +102,12 @@ class MediaMessage(Message):
         with open(filename, "wb") as f:
             f.write(ioobj.getvalue())
         return filename
+    
+    def save_media_base64(self, force_download=False):
+        # gets full media
+        ioobj = self.driver.download_media(self, force_download)
+        return b64encode(ioobj.getvalue()).decode()
+
 
     def __repr__(self):
         return "<MediaMessage - {type} from {sender} at {timestamp} ({filename})>".format(

--- a/webwhatsapi/wapi_js_wrapper.py
+++ b/webwhatsapi/wapi_js_wrapper.py
@@ -64,15 +64,16 @@ class WapiJsWrapper(object):
         except NameError:
             script_path = os.getcwd()
 
-        result = self.driver.execute_script(
-            "if (document.querySelector('*[data-icon=chat]') !== null) { return true } else { return false }")  # noqa E501
+        result = self.driver.execute_script("if (document.querySelector('*[data-icon=chat]') !== null) { return true } else { return false }")  # noqa E501
+        
         if result:
             with open(os.path.join(script_path, "js", "wapi.js"), "r") as script:
                 self.driver.execute_script(script.read())
 
-            result = self.driver.execute_script("return window.WAPI")
+            result = self.driver.execute_script("return Object.keys(window.WAPI)")
+
             if result:
-                self.available_functions = result.keys()
+                self.available_functions = result
                 return self.available_functions
             else:
                 return []


### PR DESCRIPTION
Now you can use it in the latest versions of firefox and chrome.

The bug was that the code stopped at **_self.driver.execute_script ("return window.WAPI")_**
so it never saved the object in **_available_functions_.**
That is, every time he replaced **_wapi.js_** on the page making this error happen


Along with that I sent the **webpackJsonp** fix
and the **executable_path** for the chrome browser

***

Fixed bug in the generation of base64 qrcode _(get_qr_base64)_ and plain _(get_qr_plain)_. In addition to the qrcode selector _('qrCode': "canvas[aria-label=\"Scan me!\"]")_ correction

***
Added two media sending functions. One sends media from a **base64 string** + **content_type**  _(send_media_base64)_ and the other sends from a URL _(send_media_url)_.
A function has also been added to return the base64 string of a received media _(save_media_base64)_

*** 
Bug fixed headless at the Chrome


