### PR TITLE
Fix group metadata retrieval

### DIFF
--- a/webwhatsapi/js/wapi.js
+++ b/webwhatsapi/js/wapi.js
@@ -541,7 +541,7 @@ window.WAPI.getGroupMetadata = async function (id, done) {
 
     if (output !== undefined) {
         if (output.stale) {
-            await output.update();
+            await window.Store.GroupMetadata.update(id);
         }
     }
 


### PR DESCRIPTION
The update method is now not part of each group metadata object, but we can achieve the same functionality from the global `window.Store.GroupMetadata` object.