### PR TITLE
Add async check_number_status to WhatsAPIDriverAsync

### DIFF
--- a/webwhatsapi/async_driver.py
+++ b/webwhatsapi/async_driver.py
@@ -133,6 +133,9 @@ class WhatsAPIDriverAsync:
     async def get_status(self):
         return await self._run_async(self._driver.get_status)
 
+    async def check_number_status(self, number_id):
+        return await self._run_async(self._driver.check_number_status, number_id)
+
     async def contact_get_common_groups(self, contact_id):
         groups = await self._run_async(
             self._driver.contact_get_common_groups(contact_id), contact_id


### PR DESCRIPTION
When working with your project, I missed a method to check if a specif phone number was able to receive messages, but in an asynchronous manner so I added and tested the same synchronous method to WhatsAPIDriverAsync in order to use it.
closes #949 